### PR TITLE
Updating main.tf and composer.tf to destroy composer SAs

### DIFF
--- a/terraform/envs/dev/main.tf
+++ b/terraform/envs/dev/main.tf
@@ -25,15 +25,15 @@ provider "google-beta" {
 
 
 #### Define Cloud Composer resource - note this is toggled on/off using dev.auto.tfvars ####
-
-module "composer" {
-  count = var.enable_composer ? 1 : 0
-
-  source                = "../../modules/composer"
-  name                  = "dev-composer"
-  region                = var.region
-  service_account_email = module.iam.composer_service_account_email
-}
+#### Commented out as Composer is too big to set up in a GCP Trail project - Service accounts definitions set to disused in IAM modules (composer.tf.disused and outputs.tf.disused)
+#module "composer" {
+#  count = var.enable_composer ? 1 : 0
+#
+#  source                = "../../modules/composer"
+#  name                  = "dev-composer"
+#  region                = var.region
+#  service_account_email = module.iam.composer_service_account_email
+#}
 
 
 #### Service account creation and permissions ####

--- a/terraform/modules/iam/composer.tf.disused
+++ b/terraform/modules/iam/composer.tf.disused
@@ -1,3 +1,5 @@
+#### Set to disused as Composer is too big to set up in a GCP Trail project ####
+
 ############################
 # Composer runtime identity
 ############################

--- a/terraform/modules/iam/outputs.tf.disused
+++ b/terraform/modules/iam/outputs.tf.disused
@@ -1,3 +1,5 @@
+#### Set to disused as Composer is too big to set up in a GCP Trail project ####
+
 output "composer_service_account_email" {
   description = "Composer runtime service account email"
   value       = google_service_account.composer.email


### PR DESCRIPTION
These accounts aren't required whilst the project is in trail state (Composer is too big for quotas)