### PR TITLE
Removing port 8080 access

### DIFF
--- a/terraform/modules/network/firewall_airflow.tf
+++ b/terraform/modules/network/firewall_airflow.tf
@@ -1,18 +1,19 @@
-resource "google_compute_firewall" "airflow_ui" {
-  project = var.project_id
-  name    = "${var.network_name}-allow-airflow-ui"
-  network = google_compute_network.this.self_link
-
-  allow {
-    protocol = "tcp"
-    ports    = ["8080"]
-  }
-
-  source_ranges           = var.airflow_ui_source_ranges
-  target_service_accounts = [var.airflow_service_account_email]
-
-  direction = "INGRESS"
-}
+#### Commenting this rule out to prevent exposing port 8080 to the internet. UI access should be via SSH ####
+#resource "google_compute_firewall" "airflow_ui" {
+#  project = var.project_id
+#  name    = "${var.network_name}-allow-airflow-ui"
+#  network = google_compute_network.this.self_link
+#
+#  allow {
+#    protocol = "tcp"
+#    ports    = ["8080"]
+#  }
+#
+#  source_ranges           = var.airflow_ui_source_ranges
+#  target_service_accounts = [var.airflow_service_account_email]
+#
+#  direction = "INGRESS"
+#}
 
 
 resource "google_compute_firewall" "ssh_ingress" {


### PR DESCRIPTION
Prevent exposing port 8080 to the internet. UI access should be via SSH